### PR TITLE
Update fxmanifest.lua

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -19,5 +19,6 @@ server_script "server/**/*"
 
 files {
   'web/build/index.html',
-  'web/build/**/*'
+  'web/build/static/**',
+  'web/build/asset-manifest.json'
 }


### PR DESCRIPTION
I personally used your resource for a long time and noticed over several builds that the react build folder was increasing and each build and the resource streamer of fivem in according with your fxmanifest was always streaming all the build folder. After the changes I made to the manifest it went from 300mb to 7mb in my case with significative decrease in terms of storage and streaming speed and script environment for fivem.