### PR TITLE
Fix: prevent an error when browser developing

### DIFF
--- a/web/src/providers/VisibilityProvider.tsx
+++ b/web/src/providers/VisibilityProvider.tsx
@@ -1,6 +1,7 @@
 import React, {Context, createContext, useContext, useEffect, useState} from "react";
 import {useNuiEvent} from "../hooks/useNuiEvent";
 import {fetchNui} from "../utils/fetchNui";
+import { isEnvBrowser } from "../utils/misc";
 
 const VisibilityCtx = createContext<VisibilityProviderValue | null>(null)
 
@@ -23,7 +24,8 @@ export const VisibilityProvider: React.FC = ({children}) => {
 
     const keyHandler = (e: KeyboardEvent) => {
       if (["Backspace", "Escape"].includes(e.code)) {
-        fetchNui('hideFrame')
+        if (!isEnvBrowser) fetchNui("hideFrame");
+        else setVisible(!visible);
       }
     }
 


### PR DESCRIPTION
When developing purely in the browser if you would press escape or backspace it would produce errors, since it was sending fetchnui to things that don't exist in the browser environment.

I simply added a check for if isEnvBrowser. And if so just toggle the visibility. 
