### PR TITLE
ci(release/build): update node version to 20.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup node environment
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 20.x
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -29,4 +29,3 @@ jobs:
         run: yarn --frozen-lockfile
       - name: Try build
         run: yarn build
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@v1'
         with:
-          node-version: 14.x
+          node-version: 20.x
       - name: Create release
         uses: marvinpinto/action-automatic-releases@latest
         with:


### PR DESCRIPTION
**Pull Request Description**

Hi! The current workflows are broken since node 14 has reached end of life and is no longer supported by the majority of packages. I ran into this error from `@typescript-eslint/eslint-plugin`, but I'm pretty sure most other packages (if not all) used in this template no longer support it either. In this pull request I simply updated the node version in the workflows to the latest LTS version, which is 20 at the time of writing.

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open for the same update/change?
* [ ] Have you built and tested the `resource` in-game after the relevant change?

_Last one is not applicable due to this being a change to the CI workflows._
